### PR TITLE
fix: Include schemas in the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     if: ${{ needs.release.outputs.release_created }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
The release process was not pulling the submodules thus the schemas were excluded from the released archive.