### PR TITLE
Update build generator to prevent adding nulls on marshalling 

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -21,5 +21,5 @@ jobs:
             git add .
             git config --global user.name ${{ github.actor }}
             git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-            git commit -a -m 'Regenerate types' && git push
+            git commit -a -m 'fix: Regenerate types' && git push
           fi

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.target>${java.release}</maven.compiler.target>
     <maven.compiler.source>${java.release}</maven.compiler.source>
+    <junit.version>5.9.2</junit.version>
   </properties>
 
   <licenses>
@@ -63,6 +64,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/scripts/CloudEventJavaLanguage.js
+++ b/scripts/CloudEventJavaLanguage.js
@@ -1,0 +1,27 @@
+const {getOptionValues, javaOptions, JavaTargetLanguage} = require("quicktype-core") ;
+const {JacksonRenderer} = require("quicktype-core/dist/language/Java");
+
+class CloudEventJavaLanguage extends JavaTargetLanguage {
+    constructor() {
+        super('Java', ['Java'], 'java');
+    }
+
+    makeRenderer(renderContext, untypedOptionValues) {
+        return new CloudEventJacksonRenderer(this, renderContext, getOptionValues(javaOptions, untypedOptionValues));
+    }
+}
+
+class CloudEventJacksonRenderer extends JacksonRenderer {
+    annotationsForAccessor(_c, _className, _propertyName, jsonName, p, _isSetter) {
+        const annotations = super.annotationsForAccessor(_c, _className, _propertyName, jsonName, p, _isSetter);
+        if (!_c.isNullable) {
+            annotations.push('@JsonInclude(JsonInclude.Include.NON_NULL)');
+        }
+
+        return annotations;
+    }
+}
+
+module.exports = {
+    CloudEventJavaLanguage
+};

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -2,13 +2,14 @@ const {
   quicktypeMultiFile,
   InputData,
   JSONSchemaInput,
-  JSONSchemaStore,
+  JSONSchemaStore, JavaTargetLanguage,
 } = require("quicktype-core");
 const { execSync } = require("child_process");
 const fsPromises = require("fs/promises");
 const fs = require("fs");
 const path = require("path");
 const { chdir } = require("process");
+const {CloudEventJavaLanguage} = require("./CloudEventJavaLanguage");
 const BASE_JAVA_PACKAGE = 'com.redhat.cloud.event';
 const BASE_JAVA_SRC_PATH = "src/main/java";
 
@@ -48,9 +49,10 @@ async function generateJavaFiles(subdir, version, inputData, _schema) {
   const subPackage = `${subdir.replaceAll('/', '.')}.${version}`;
   const packageName = `${BASE_JAVA_PACKAGE}.${subPackage}`;
   const outputPath = `${BASE_JAVA_SRC_PATH}/${packageName.replaceAll('.', '/')}`;
+  const lang = new CloudEventJavaLanguage();
   const result = await quicktypeMultiFile({
     inputData,
-    lang: "java",
+    lang,
     rendererOptions: {
       package: packageName,
     },

--- a/src/main/java/com/redhat/cloud/event/apps/advisor/v1/AdvisorRecommendation.java
+++ b/src/main/java/com/redhat/cloud/event/apps/advisor/v1/AdvisorRecommendation.java
@@ -12,32 +12,44 @@ public class AdvisorRecommendation {
     private String totalRisk;
 
     @JsonProperty("publish_date")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public OffsetDateTime getPublishDate() { return publishDate; }
     @JsonProperty("publish_date")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setPublishDate(OffsetDateTime value) { this.publishDate = value; }
 
     @JsonProperty("reboot_required")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public boolean getRebootRequired() { return rebootRequired; }
     @JsonProperty("reboot_required")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRebootRequired(boolean value) { this.rebootRequired = value; }
 
     @JsonProperty("rule_description")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRuleDescription() { return ruleDescription; }
     @JsonProperty("rule_description")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRuleDescription(String value) { this.ruleDescription = value; }
 
     @JsonProperty("rule_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRuleID() { return ruleID; }
     @JsonProperty("rule_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRuleID(String value) { this.ruleID = value; }
 
     @JsonProperty("rule_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRuleURL() { return ruleURL; }
     @JsonProperty("rule_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRuleURL(String value) { this.ruleURL = value; }
 
     @JsonProperty("total_risk")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getTotalRisk() { return totalRisk; }
     @JsonProperty("total_risk")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setTotalRisk(String value) { this.totalRisk = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/advisor/v1/AdvisorRecommendations.java
+++ b/src/main/java/com/redhat/cloud/event/apps/advisor/v1/AdvisorRecommendations.java
@@ -13,12 +13,16 @@ public class AdvisorRecommendations {
      * Advisor recommendations for a system
      */
     @JsonProperty("advisor_recommendations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public AdvisorRecommendation[] getAdvisorRecommendations() { return advisorRecommendations; }
     @JsonProperty("advisor_recommendations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setAdvisorRecommendations(AdvisorRecommendation[] value) { this.advisorRecommendations = value; }
 
     @JsonProperty("system")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public RHELSystem getSystem() { return system; }
     @JsonProperty("system")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setSystem(RHELSystem value) { this.system = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/advisor/v1/RHELSystem.java
+++ b/src/main/java/com/redhat/cloud/event/apps/advisor/v1/RHELSystem.java
@@ -19,37 +19,51 @@ public class RHELSystem {
      * Timestamp of when the system did a check in. Must adhere to RFC 3339.
      */
     @JsonProperty("check_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public OffsetDateTime getCheckIn() { return checkIn; }
     @JsonProperty("check_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setCheckIn(OffsetDateTime value) { this.checkIn = value; }
 
     @JsonProperty("display_name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDisplayName() { return displayName; }
     @JsonProperty("display_name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setDisplayName(String value) { this.displayName = value; }
 
     @JsonProperty("host_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostURL() { return hostURL; }
     @JsonProperty("host_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setHostURL(String value) { this.hostURL = value; }
 
     @JsonProperty("hostname")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostname() { return hostname; }
     @JsonProperty("hostname")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setHostname(String value) { this.hostname = value; }
 
     @JsonProperty("inventory_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getInventoryID() { return inventoryID; }
     @JsonProperty("inventory_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setInventoryID(String value) { this.inventoryID = value; }
 
     @JsonProperty("rhel_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRHELVersion() { return rhelVersion; }
     @JsonProperty("rhel_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRHELVersion(String value) { this.rhelVersion = value; }
 
     @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public RHELSystemTag[] getTags() { return tags; }
     @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setTags(RHELSystemTag[] value) { this.tags = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/advisor/v1/RHELSystemTag.java
+++ b/src/main/java/com/redhat/cloud/event/apps/advisor/v1/RHELSystemTag.java
@@ -8,17 +8,23 @@ public class RHELSystemTag {
     private String value;
 
     @JsonProperty("key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getKey() { return key; }
     @JsonProperty("key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setKey(String value) { this.key = value; }
 
     @JsonProperty("namespace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getNamespace() { return namespace; }
     @JsonProperty("namespace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setNamespace(String value) { this.namespace = value; }
 
     @JsonProperty("value")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getValue() { return value; }
     @JsonProperty("value")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setValue(String value) { this.value = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/policies/v1/Policy.java
+++ b/src/main/java/com/redhat/cloud/event/apps/policies/v1/Policy.java
@@ -10,27 +10,37 @@ public class Policy {
     private String url;
 
     @JsonProperty("condition")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getCondition() { return condition; }
     @JsonProperty("condition")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setCondition(String value) { this.condition = value; }
 
     @JsonProperty("description")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDescription() { return description; }
     @JsonProperty("description")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setDescription(String value) { this.description = value; }
 
     @JsonProperty("id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getID() { return id; }
     @JsonProperty("id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setID(String value) { this.id = value; }
 
     @JsonProperty("name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getName() { return name; }
     @JsonProperty("name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setName(String value) { this.name = value; }
 
     @JsonProperty("url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getURL() { return url; }
     @JsonProperty("url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setURL(String value) { this.url = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/policies/v1/PolicyTriggered.java
+++ b/src/main/java/com/redhat/cloud/event/apps/policies/v1/PolicyTriggered.java
@@ -13,12 +13,16 @@ public class PolicyTriggered {
      * Triggered policies for a system
      */
     @JsonProperty("policies")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Policy[] getPolicies() { return policies; }
     @JsonProperty("policies")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setPolicies(Policy[] value) { this.policies = value; }
 
     @JsonProperty("system")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public SystemClass getSystem() { return system; }
     @JsonProperty("system")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setSystem(SystemClass value) { this.system = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/policies/v1/RHELSystemTag.java
+++ b/src/main/java/com/redhat/cloud/event/apps/policies/v1/RHELSystemTag.java
@@ -8,17 +8,23 @@ public class RHELSystemTag {
     private String value;
 
     @JsonProperty("key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getKey() { return key; }
     @JsonProperty("key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setKey(String value) { this.key = value; }
 
     @JsonProperty("namespace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getNamespace() { return namespace; }
     @JsonProperty("namespace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setNamespace(String value) { this.namespace = value; }
 
     @JsonProperty("value")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getValue() { return value; }
     @JsonProperty("value")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setValue(String value) { this.value = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/apps/policies/v1/SystemClass.java
+++ b/src/main/java/com/redhat/cloud/event/apps/policies/v1/SystemClass.java
@@ -19,37 +19,51 @@ public class SystemClass {
      * Timestamp of when the system did a check in. Must adhere to RFC 3339.
      */
     @JsonProperty("check_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public OffsetDateTime getCheckIn() { return checkIn; }
     @JsonProperty("check_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setCheckIn(OffsetDateTime value) { this.checkIn = value; }
 
     @JsonProperty("display_name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDisplayName() { return displayName; }
     @JsonProperty("display_name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setDisplayName(String value) { this.displayName = value; }
 
     @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public RHELSystemTag[] getTags() { return tags; }
     @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setTags(RHELSystemTag[] value) { this.tags = value; }
 
     @JsonProperty("host_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostURL() { return hostURL; }
     @JsonProperty("host_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setHostURL(String value) { this.hostURL = value; }
 
     @JsonProperty("hostname")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostname() { return hostname; }
     @JsonProperty("hostname")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setHostname(String value) { this.hostname = value; }
 
     @JsonProperty("inventory_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getInventoryID() { return inventoryID; }
     @JsonProperty("inventory_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setInventoryID(String value) { this.inventoryID = value; }
 
     @JsonProperty("rhel_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRHELVersion() { return rhelVersion; }
     @JsonProperty("rhel_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRHELVersion(String value) { this.rhelVersion = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/Error.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/Error.java
@@ -9,7 +9,9 @@ public class Error {
     private ErrorClass error;
 
     @JsonProperty("error")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public ErrorClass getError() { return error; }
     @JsonProperty("error")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setError(ErrorClass value) { this.error = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/ErrorClass.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/ErrorClass.java
@@ -15,31 +15,39 @@ public class ErrorClass {
      * Machine-readable error code that identifies the error.
      */
     @JsonProperty("code")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getCode() { return code; }
     @JsonProperty("code")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setCode(String value) { this.code = value; }
 
     /**
      * Human readable description of the error.
      */
     @JsonProperty("message")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getMessage() { return message; }
     @JsonProperty("message")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setMessage(String value) { this.message = value; }
 
     /**
      * The severity of the error.
      */
     @JsonProperty("severity")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Severity getSeverity() { return severity; }
     @JsonProperty("severity")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setSeverity(Severity value) { this.severity = value; }
 
     /**
      * The stack trace/traceback (optional)
      */
     @JsonProperty("stack_trace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getStackTrace() { return stackTrace; }
     @JsonProperty("stack_trace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setStackTrace(String value) { this.stackTrace = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/Notification.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/Notification.java
@@ -11,7 +11,9 @@ public class Notification {
     private Recipients notificationRecipients;
 
     @JsonProperty("notification_recipients")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Recipients getNotificationRecipients() { return notificationRecipients; }
     @JsonProperty("notification_recipients")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setNotificationRecipients(Recipients value) { this.notificationRecipients = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/RHELSystem.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/RHELSystem.java
@@ -9,7 +9,9 @@ public class RHELSystem {
     private SystemClass system;
 
     @JsonProperty("system")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public SystemClass getSystem() { return system; }
     @JsonProperty("system")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setSystem(SystemClass value) { this.system = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/RHELSystemTag.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/RHELSystemTag.java
@@ -8,17 +8,23 @@ public class RHELSystemTag {
     private String value;
 
     @JsonProperty("key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getKey() { return key; }
     @JsonProperty("key")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setKey(String value) { this.key = value; }
 
     @JsonProperty("namespace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getNamespace() { return namespace; }
     @JsonProperty("namespace")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setNamespace(String value) { this.namespace = value; }
 
     @JsonProperty("value")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getValue() { return value; }
     @JsonProperty("value")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setValue(String value) { this.value = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/Recipients.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/Recipients.java
@@ -16,8 +16,10 @@ public class Recipients {
      * Setting to false honors the user preferences.
      */
     @JsonProperty("ignore_user_preferences")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getIgnoreUserPreferences() { return ignoreUserPreferences; }
     @JsonProperty("ignore_user_preferences")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setIgnoreUserPreferences(Boolean value) { this.ignoreUserPreferences = value; }
 
     /**
@@ -25,8 +27,10 @@ public class Recipients {
      * sends an email to all users of the account.
      */
     @JsonProperty("only_admins")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Boolean getOnlyAdmins() { return onlyAdmins; }
     @JsonProperty("only_admins")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setOnlyAdmins(Boolean value) { this.onlyAdmins = value; }
 
     /**
@@ -34,7 +38,9 @@ public class Recipients {
      * administrators settings. Users list will be merged with other settings.
      */
     @JsonProperty("users")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String[] getUsers() { return users; }
     @JsonProperty("users")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setUsers(String[] value) { this.users = value; }
 }

--- a/src/main/java/com/redhat/cloud/event/core/v1/SystemClass.java
+++ b/src/main/java/com/redhat/cloud/event/core/v1/SystemClass.java
@@ -19,37 +19,51 @@ public class SystemClass {
      * Timestamp of when the system did a check in. Must adhere to RFC 3339.
      */
     @JsonProperty("check_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public OffsetDateTime getCheckIn() { return checkIn; }
     @JsonProperty("check_in")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setCheckIn(OffsetDateTime value) { this.checkIn = value; }
 
     @JsonProperty("display_name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getDisplayName() { return displayName; }
     @JsonProperty("display_name")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setDisplayName(String value) { this.displayName = value; }
 
     @JsonProperty("host_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostURL() { return hostURL; }
     @JsonProperty("host_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setHostURL(String value) { this.hostURL = value; }
 
     @JsonProperty("hostname")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getHostname() { return hostname; }
     @JsonProperty("hostname")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setHostname(String value) { this.hostname = value; }
 
     @JsonProperty("inventory_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getInventoryID() { return inventoryID; }
     @JsonProperty("inventory_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setInventoryID(String value) { this.inventoryID = value; }
 
     @JsonProperty("rhel_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getRHELVersion() { return rhelVersion; }
     @JsonProperty("rhel_version")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setRHELVersion(String value) { this.rhelVersion = value; }
 
     @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public RHELSystemTag[] getTags() { return tags; }
     @JsonProperty("tags")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public void setTags(RHELSystemTag[] value) { this.tags = value; }
 }

--- a/src/test/java/com/redhat/cloud/event/core/ParserTest.java
+++ b/src/test/java/com/redhat/cloud/event/core/ParserTest.java
@@ -1,0 +1,33 @@
+package com.redhat.cloud.event.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.event.core.v1.RHELSystem;
+import com.redhat.cloud.event.core.v1.SystemClass;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ParserTest {
+
+    @Test
+    public void omitEmptyFieldsTest() throws JsonProcessingException {
+        RHELSystem rhelSystem = new RHELSystem();
+        SystemClass system = new SystemClass();
+        system.setInventoryID(UUID.randomUUID().toString());
+        rhelSystem.setSystem(system);
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        String jsonString = mapper.writeValueAsString(rhelSystem);
+
+        JsonNode node = mapper.readTree(jsonString).get("system");
+
+        assertNull(system.getDisplayName());
+        assertFalse(node.has("display_name"));
+    }
+}


### PR DESCRIPTION
By default, if the fields don't have a value they are set to null. 
When marshalling happens, the null fields are added as `field: null` and this breaks the schema.

Adding `@JsonInclude(JsonInclude.Include.NON_NULL)` prevents from adding these fields in case they are null. 

To include this as part of the quicktype generation, followed this [guide](https://blog.quicktype.io/customizing-quicktype/) to extend the Java language/renderer from quicktype and append the annotations on the fields that are not nullable.