### PR TITLE
feat: Adds ability to parse and validate the whole message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.0.79</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEvent.java
+++ b/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEvent.java
@@ -14,6 +14,9 @@ public class ConsoleCloudEvent {
 
     String source;
 
+    @JsonProperty("specversion")
+    String specVersion;
+
     String subject;
 
     LocalDateTime time;
@@ -45,6 +48,14 @@ public class ConsoleCloudEvent {
 
     public void setSource(String source) {
         this.source = source;
+    }
+
+    public String getSpecVersion() {
+        return specVersion;
+    }
+
+    public void setSpecVersion(String specVersion) {
+        this.specVersion = specVersion;
     }
 
     public String getSubject() {

--- a/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEvent.java
+++ b/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEvent.java
@@ -1,0 +1,105 @@
+package com.redhat.cloud.event.parser;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConsoleCloudEvent {
+
+    UUID id;
+
+    String source;
+
+    String subject;
+
+    LocalDateTime time;
+
+    String type;
+
+    @JsonProperty("dataschema")
+    String dataSchema;
+
+    JsonNode data;
+
+    @JsonProperty("redhatorgid")
+    String orgId;
+
+    @JsonProperty("redhataccount")
+    String accountId;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public void setTime(LocalDateTime time) {
+        this.time = time;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getDataSchema() {
+        return dataSchema;
+    }
+
+    public void setDataSchema(String dataSchema) {
+        this.dataSchema = dataSchema;
+    }
+
+    public JsonNode getData() {
+        return data;
+    }
+
+    public void setData(JsonNode data) {
+        this.data = data;
+    }
+
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+}

--- a/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEventParser.java
+++ b/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEventParser.java
@@ -1,0 +1,135 @@
+package com.redhat.cloud.event.parser;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.networknt.schema.ApplyDefaultsStrategy;
+import com.networknt.schema.JsonMetaSchema;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaException;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaValidatorsConfig;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationResult;
+import com.networknt.schema.ValidatorTypeCode;
+import com.networknt.schema.uri.URIFactory;
+import com.networknt.schema.uri.URLFactory;
+import com.redhat.cloud.event.core.v1.RHELSystem;
+import com.redhat.cloud.event.parser.validators.LocalDateTimeValidator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+public class ConsoleCloudEventParser {
+
+    private static final String schemaPath = "/schemas/events/v1/events.json";
+
+    static class CloudEventURIFactory implements URIFactory {
+
+        private static final String baseUrl = "https://console.redhat.com/api";
+        private final URLFactory urlFactory = new URLFactory();
+        private final String base;
+
+        CloudEventURIFactory() {
+            String fullPath = RHELSystem.class.getResource(schemaPath).toString();
+            base = fullPath.substring(0, fullPath.length() - schemaPath.length());
+        }
+
+        @Override
+        public URI create(String uri) {
+            return urlFactory.create(replaceBase(uri));
+        }
+
+        @Override
+        public URI create(URI baseURI, String segment) {
+            return urlFactory.create(URI.create(replaceBase(baseURI.toString())), segment);
+        }
+
+        private String replaceBase(String uri) {
+            if (uri.startsWith(baseUrl)) {
+                uri = base + uri.substring(baseUrl.length(), uri.length() - 1);
+            }
+
+            return uri;
+        }
+    }
+
+    ObjectMapper objectMapper;
+
+    JsonSchema jsonSchema;
+
+    public ConsoleCloudEventParser() {
+        this(buildObjectMapper());
+    }
+
+    public ConsoleCloudEventParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        jsonSchema = getJsonSchema();
+    }
+
+    public ConsoleCloudEvent fromJsonString(String cloudEventJson) {
+        return fromJsonString(cloudEventJson, ConsoleCloudEvent.class);
+    }
+
+    public <T extends ConsoleCloudEvent> T fromJsonString(String cloudEventJson, Class<T> consoleCloudEventClass) {
+        try {
+            // Verify it's a valid Json
+            JsonNode cloudEvent = objectMapper.readTree(cloudEventJson);
+            ValidationResult result = jsonSchema.walk(cloudEvent, true);
+
+            if (result.getValidationMessages().size() > 0) {
+                throw new ConsoleCloudEventParsingException("Cloud event validation failed for: " + cloudEventJson + ". Failures: " + result.getValidationMessages().toString());
+            }
+
+            return objectMapper.treeToValue(cloudEvent, consoleCloudEventClass);
+        } catch (JsonProcessingException jme) {
+            throw new ConsoleCloudEventParsingException("Cloud event parsing failed for: " + cloudEventJson, jme);
+        }
+    }
+
+    private static ObjectMapper buildObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+
+    private JsonSchema getJsonSchema() {
+        SchemaValidatorsConfig schemaValidatorsConfig = new SchemaValidatorsConfig();
+        schemaValidatorsConfig.setApplyDefaultsStrategy(new ApplyDefaultsStrategy(
+                true,
+                true,
+                true
+        ));
+
+        try (InputStream jsonSchemaStream = RHELSystem.class.getResourceAsStream(schemaPath)) {
+            JsonNode schema = objectMapper.readTree(jsonSchemaStream);
+
+            return jsonSchemaFactory().getSchema(
+                    schema,
+                    schemaValidatorsConfig
+            );
+        } catch (IOException ioe) {
+            throw new JsonSchemaException(ioe);
+        }
+    }
+
+    private static JsonSchemaFactory jsonSchemaFactory() {
+        String ID = "$id";
+
+        JsonMetaSchema overrideDateTimeValidator = new JsonMetaSchema.Builder(JsonMetaSchema.getV7().getUri())
+                .idKeyword(ID)
+                .addKeywords(ValidatorTypeCode.getNonFormatKeywords(SpecVersion.VersionFlag.V7))
+                .addFormats(JsonMetaSchema.COMMON_BUILTIN_FORMATS)
+                .addFormat(new LocalDateTimeValidator())
+                .build();
+
+        return new JsonSchemaFactory.Builder().defaultMetaSchemaURI(overrideDateTimeValidator.getUri())
+                .addMetaSchema(overrideDateTimeValidator)
+                .uriFactory(new CloudEventURIFactory(), "https")
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEventParsingException.java
+++ b/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEventParsingException.java
@@ -1,0 +1,12 @@
+package com.redhat.cloud.event.parser;
+
+public class ConsoleCloudEventParsingException extends RuntimeException {
+
+    public ConsoleCloudEventParsingException(String message) {
+        super(message);
+    }
+
+    public ConsoleCloudEventParsingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/redhat/cloud/event/parser/validators/LocalDateTimeValidator.java
+++ b/src/main/java/com/redhat/cloud/event/parser/validators/LocalDateTimeValidator.java
@@ -1,0 +1,32 @@
+package com.redhat.cloud.event.parser.validators;
+
+import com.networknt.schema.Format;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class LocalDateTimeValidator implements Format {
+
+    private String message;
+
+    @Override
+    public String getName() {
+        return "date-time";
+    }
+
+    @Override
+    public boolean matches(String text) {
+        try {
+            DateTimeFormatter.ISO_DATE_TIME.parse(text);
+            return true;
+        } catch (DateTimeParseException exception) {
+            message = exception.getMessage();
+            return false;
+        }
+    }
+
+    @Override
+    public String getErrorMessageDescription() {
+        return message;
+    }
+}

--- a/src/test/java/com/redhat/cloud/event/parser/ConsoleCloudEventParserTest.java
+++ b/src/test/java/com/redhat/cloud/event/parser/ConsoleCloudEventParserTest.java
@@ -1,0 +1,46 @@
+package com.redhat.cloud.event.parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ConsoleCloudEventParserTest {
+
+    @Test
+    public void shouldParseCorrectCloudEvents() throws IOException {
+        ConsoleCloudEventParser consoleCloudEventParser = new ConsoleCloudEventParser();
+
+        ConsoleCloudEvent consoleCloudEvent = consoleCloudEventParser.fromJsonString(readSchema("cloud-events/advisor.json"));
+
+        assertEquals("com.redhat.console.advisor.new-recommendations", consoleCloudEvent.getType());
+        assertEquals("org123", consoleCloudEvent.getOrgId());
+        assertNull(consoleCloudEvent.getAccountId());
+    }
+
+    @Test
+    public void shouldFailOnNonCompliantCloudEvents() {
+        ConsoleCloudEventParser consoleCloudEventParser = new ConsoleCloudEventParser();
+        assertThrows(RuntimeException.class, () -> consoleCloudEventParser.fromJsonString(readSchema("cloud-events/advisor-invalid.json")));
+    }
+
+    @Test
+    public void shouldFailOnInvalidJson() throws IOException {
+        ConsoleCloudEventParser consoleCloudEventParser = new ConsoleCloudEventParser();
+
+        assertThrows(RuntimeException.class, () -> consoleCloudEventParser.fromJsonString("hello world"));
+    }
+
+    private String readSchema(String path) throws IOException {
+        InputStream content = ConsoleCloudEventParserTest.class.getClassLoader().getResourceAsStream(path);
+        assertNotNull(content, "could not load example cloud event for advisor");
+        return new String(content.readAllBytes(), UTF_8);
+    }
+}

--- a/src/test/resources/cloud-events/advisor-invalid.json
+++ b/src/test/resources/cloud-events/advisor-invalid.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
+  "id": "not-a-uuid",
+  "source": "urn:redhat:source:console:app:advisor",
+  "specversion": "1.0",
+  "type": "com.redhat.console.advisor.new-recommendations",
+  "subject": "urn:redhat:subject:console:rhel:08e8ec2b-6a79-4f1d-bea4-a438da139493",
+  "time": "2018-04-05T17:31:00Z",
+  "redhatorgid": "org123",
+  "redhatconsolebundle": "rhel",
+  "dataschema": "https://console.redhat.com/api/schemas/apps/advisor/v1/advisor-recommendations.json",
+  "data": {
+    "system": {
+      "inventory_id": "08e8ec2b-6a79-4f1d-bea4-a438da139493",
+      "hostname": "rhel8desktop",
+      "display_name": "rhel8desktop",
+      "rhel_version": "8.3",
+      "host_url": "https://console.redhat.com/insights/inventory/08e8ec2b-6a79-4f1d-bea4-a438da139493",
+      "tags": [
+        {
+          "key": "Team",
+          "value": "PMs",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Owner",
+          "value": "John Doe",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Slack",
+          "value": "username",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Contact",
+          "value": "user@redhat.com",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Location",
+          "value": "Universe",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Location",
+          "value": "Earth",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Location",
+          "value": "United States",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Application",
+          "value": "RHEL Desktop",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Cost Center",
+          "value": "MBU",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Environment",
+          "value": "Production",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Business Unit",
+          "value": "Management",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Distribution List",
+          "value": "empty",
+          "namespace": "insights-client"
+        }
+      ]
+    },
+    "advisor_recommendations": [
+      {
+        "rule_id": "insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+        "rule_description": "System is not able to get the latest recommendations and may miss bug fixes when the Insights Client Core egg file is outdated",
+        "total_risk": "2",
+        "publish_date": "2021-03-13T18:44:00+00:00",
+        "rule_url": "https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/",
+        "reboot_required": false
+      },
+      {
+        "rule_id": "empty_grubenv|EMPTY_GRUBENV_KERNELOPTS",
+        "rule_description": "Reboot fails when there is no \"kernelopts\" option in the grubenv",
+        "total_risk": "4",
+        "publish_date": "2021-11-28T03:16:00+00:00",
+        "rule_url": "https://console.redhat.com/insights/advisor/recommendations/empty_grubenv|EMPTY_GRUBENV_KERNELOPTS/",
+        "reboot_required": false
+      },
+      {
+        "rule_id": "hardening_unencrypted_avahi|HARDENING_UNENC_AVAHI",
+        "rule_description": "Decreased security when Avahi is externally accessible",
+        "total_risk": "3",
+        "publish_date": "2021-08-31T12:00:00+00:00",
+        "rule_url": "https://console.redhat.com/insights/advisor/recommendations/hardening_unencrypted_avahi|HARDENING_UNENC_AVAHI/",
+        "reboot_required": false
+      }
+    ]
+  }
+}

--- a/src/test/resources/cloud-events/advisor.json
+++ b/src/test/resources/cloud-events/advisor.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
+  "id": "8fcc8b83-e160-4b5d-8baf-2a7262ab9cd4",
+  "source": "urn:redhat:source:console:app:advisor",
+  "specversion": "1.0",
+  "type": "com.redhat.console.advisor.new-recommendations",
+  "subject": "urn:redhat:subject:console:rhel:08e8ec2b-6a79-4f1d-bea4-a438da139493",
+  "time": "2018-04-05T17:31:00Z",
+  "redhatorgid": "org123",
+  "redhatconsolebundle": "rhel",
+  "dataschema": "https://console.redhat.com/api/schemas/apps/advisor/v1/advisor-recommendations.json",
+  "data": {
+    "system": {
+      "inventory_id": "08e8ec2b-6a79-4f1d-bea4-a438da139493",
+      "hostname": "rhel8desktop",
+      "display_name": "rhel8desktop",
+      "rhel_version": "8.3",
+      "host_url": "https://console.redhat.com/insights/inventory/08e8ec2b-6a79-4f1d-bea4-a438da139493",
+      "tags": [
+        {
+          "key": "Team",
+          "value": "PMs",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Owner",
+          "value": "John Doe",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Slack",
+          "value": "username",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Contact",
+          "value": "user@redhat.com",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Location",
+          "value": "Universe",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Location",
+          "value": "Earth",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Location",
+          "value": "United States",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Application",
+          "value": "RHEL Desktop",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Cost Center",
+          "value": "MBU",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Environment",
+          "value": "Production",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Business Unit",
+          "value": "Management",
+          "namespace": "insights-client"
+        },
+        {
+          "key": "Distribution List",
+          "value": "empty",
+          "namespace": "insights-client"
+        }
+      ]
+    },
+    "advisor_recommendations": [
+      {
+        "rule_id": "insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE",
+        "rule_description": "System is not able to get the latest recommendations and may miss bug fixes when the Insights Client Core egg file is outdated",
+        "total_risk": "2",
+        "publish_date": "2021-03-13T18:44:00+00:00",
+        "rule_url": "https://console.redhat.com/insights/advisor/recommendations/insights_core_egg_not_up2date|INSIGHTS_CORE_EGG_NOT_UP2DATE/",
+        "reboot_required": false
+      },
+      {
+        "rule_id": "empty_grubenv|EMPTY_GRUBENV_KERNELOPTS",
+        "rule_description": "Reboot fails when there is no \"kernelopts\" option in the grubenv",
+        "total_risk": "4",
+        "publish_date": "2021-11-28T03:16:00+00:00",
+        "rule_url": "https://console.redhat.com/insights/advisor/recommendations/empty_grubenv|EMPTY_GRUBENV_KERNELOPTS/",
+        "reboot_required": false
+      },
+      {
+        "rule_id": "hardening_unencrypted_avahi|HARDENING_UNENC_AVAHI",
+        "rule_description": "Decreased security when Avahi is externally accessible",
+        "total_risk": "3",
+        "publish_date": "2021-08-31T12:00:00+00:00",
+        "rule_url": "https://console.redhat.com/insights/advisor/recommendations/hardening_unencrypted_avahi|HARDENING_UNENC_AVAHI/",
+        "reboot_required": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Generic parser object for cloud events wrapper. The wrapper itself does not have specifc java attributes of each application but does take care of the validation. i.e. while it does not have the policies data, it ensures that if the `data` is from policies, the content is valid.