### PR TITLE
chore: Add missing github_token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           MERGE_RETRIES: 10
           MERGE_RETRY_SLEEP: 10000
           PULL_REQUEST: ${{ fromJSON(needs.release.outputs.pr).number }}
-
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   publish:
     needs: [ release ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is required for the auto merge of the snapshots