### PR TITLE
chore: Build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,20 +9,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Prepare cache key
-        id: cache-key
-        shell: bash
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
-      - name: Cache Maven dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          # The cache key is changed every month to prevent unlimited growth.
-          key: maven-cache-${{ steps.cache-key.outputs.date }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: adopt
           java-version: 17
+          cache: maven
       - name: Build with Maven
         run: ./mvnw clean verify --no-transfer-progress

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -16,10 +16,21 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm run generate
-      - run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git add .
-            git config --global user.name ${{ github.actor }}
-            git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-            git commit -a -m 'fix: Regenerate types' && git push
-          fi
+      - name: Check if there are changes
+        id: changes
+        uses: UnicornGlobal/has-changes-action@v1.0.11
+      - name: Set up Maven Central Repository
+        if: steps.changes.outputs.changed == 1
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: adopt
+          cache: 'maven'
+      - name: Build with Maven
+        if: steps.changes.outputs.changed == 1
+        run: ./mvnw clean verify --no-transfer-progress
+      - uses: EndBug/add-and-commit@v9
+        if: steps.changes.outputs.changed == 1
+        with:
+          default_author: github_actions
+          message: "fix: Regenerate types"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: adopt
+          cache: 'maven'
           server-id: jboss.staging
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD


### PR DESCRIPTION
- Move cache to setup-java
- Move cache to setup-java and sync java version to 17
- commit code generation from github bot instead of user account only if the result builds correctly
