### PR TITLE
chore: fix dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
       prefix: fix
       include: "scope"


### PR DESCRIPTION
Adds the missing `commit-message` field