### PR TITLE
fix: empty data doesn't get deserialized as an empty optional

### DIFF
--- a/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEvent.java
+++ b/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEvent.java
@@ -18,7 +18,7 @@ public class ConsoleCloudEvent extends GenericConsoleCloudEvent<JsonNode> {
 
     public <T> Optional<T> getData(Class<T> asClass) {
         try {
-            return Optional.of(this.objectMapper.treeToValue(this.getData(), asClass));
+            return Optional.ofNullable(this.objectMapper.treeToValue(this.getData(), asClass));
         } catch (JsonProcessingException jpe) {
             return Optional.empty();
         }

--- a/src/test/java/com/redhat/cloud/event/parser/ConsoleCloudEventParserTest.java
+++ b/src/test/java/com/redhat/cloud/event/parser/ConsoleCloudEventParserTest.java
@@ -5,14 +5,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.cloud.event.apps.advisor.v1.AdvisorRecommendations;
+import com.redhat.cloud.event.apps.exportservice.v1.ExportRequest;
 import com.redhat.cloud.event.core.v1.Notification;
 import com.redhat.cloud.event.parser.exceptions.ConsoleCloudEventValidationException;
 import com.redhat.cloud.event.parser.modules.LocalDateTimeModule;
 import com.redhat.cloud.event.parser.modules.OffsetDateTimeModule;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -159,6 +162,16 @@ public class ConsoleCloudEventParserTest {
         ConsoleCloudEventParser consoleCloudEventParser = new ConsoleCloudEventParser();
 
         assertThrows(RuntimeException.class, () -> consoleCloudEventParser.fromJsonString("hello world"));
+    }
+
+    @Test
+    public void shouldReturnEmptyOptional() throws IOException {
+        ConsoleCloudEventParser consoleCloudEventParser = new ConsoleCloudEventParser();
+
+        final ConsoleCloudEvent cloudEvent = consoleCloudEventParser.fromJsonString(readSchema("cloud-events/export-request-empty.json"));
+        final Optional<ExportRequest> exportRequest = cloudEvent.getData(ExportRequest.class);
+
+        Assertions.assertTrue(exportRequest.isEmpty());
     }
 
     private String readSchema(String path) throws IOException {

--- a/src/test/resources/cloud-events/export-request-empty.json
+++ b/src/test/resources/cloud-events/export-request-empty.json
@@ -1,0 +1,12 @@
+{
+  "id": "d72a5b4f-2eaf-4476-8238-6dfb42dd02fe",
+  "source": "urn:redhat:source:console:app:export-service",
+  "subject": "urn:redhat:subject:export-service:request:1564b30b-ba6a-4acb-bd43-4bd9d07b3fae",
+  "time": "2023-05-24T06:04:07.321385787Z",
+  "type": "com.redhat.console.export-service.request",
+  "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
+  "specversion": "1.0",
+  "dataschema": "https://console.redhat.com/api/schemas/core/v1/empty.json",
+  "redhatorgid": "default-org-id",
+  "redhataccount": "default-account-id"
+}


### PR DESCRIPTION
When deserializing an empty event, sometimes the parser threw a NullPointerException, because the data that came in the event might have been missing.