### PR TITLE
[RHCLOUD-26089] feature: downgrade "json-schema-validator" dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <!-- Downgraded because of a bug. More details in https://issues.redhat.com/browse/RHCLOUD-26089 -->
     <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>1.0.82</version>
+      <version>1.0.81</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Josejulio realized that there is an issue with the "json-schema-validator"[1] dependency we depend on. Basically the custom formatters are not being honored, and that causes some date times to not be read as expected.

Josejulio is already working on a fix[2], but in the meantime we will downgrade the library we depend on to a previous version.

\[1\]: https://github.com/networknt/json-schema-validator/issues/784
\[2\]: https://github.com/networknt/json-schema-validator/pull/787

## Links

[[RHCLOUD-26089]](https://issues.redhat.com/browse/RHCLOUD-26089)