### PR TITLE
fix: exclude some keywords from validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <maven.compiler.target>${java.release}</maven.compiler.target>
     <maven.compiler.source>${java.release}</maven.compiler.source>
     <junit.version>5.10.1</junit.version>
+    <slf4j.version>2.0.12</slf4j.version>
   </properties>
 
   <licenses>
@@ -77,6 +78,13 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- enable logging for tests only -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEventParser.java
+++ b/src/main/java/com/redhat/cloud/event/parser/ConsoleCloudEventParser.java
@@ -164,7 +164,11 @@ public class ConsoleCloudEventParser {
                 .addKeywords(List.of(
                         new NonValidationKeyword("examples"),
                         new NonValidationKeyword("$schema"),
-                        new NonValidationKeyword("definitions")
+                        new NonValidationKeyword("definitions"),
+                        new NonValidationKeyword(ID),
+                        new NonValidationKeyword("title"),
+                        new NonValidationKeyword("description"),
+                        new NonValidationKeyword("contentEncoding")
                 ))
                 .addFormats(JsonMetaSchema.COMMON_BUILTIN_FORMATS)
                 .addFormat(new LocalDateTimeValidator())


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/rhsm-subscriptions/pull/3171
Jira issue: [SWATCH-2021](https://issues.redhat.com/browse/SWATCH-2021)

When receiving an event from Kafka like:

```json
{
  "id": "c9e01f74-6bd6-43e1-99df-1b00ae0c05f9",
  "source": "urn:redhat:source:console:app:export-service",
  "time": "2024-04-02T07:27:40.915859195",
  "type": "com.redhat.console.export-service.request",
  "data": {
    "resource_request": {
      "application": "subscriptions",
      "export_request_uuid": "fd224e48-6bfa-4c34-9dcf-6dab0e20f102",
      "filters": {},
      "format": "json",
      "resource": "subscriptions",
      "uuid": "3d67963b-f748-4bc9-817d-c2cd9f4c472a",
      "x-rh-identity": "MTMyNTk3NzU="
    }
  },
  "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
  "specversion": "1.0",
  "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
  "redhatorgid": "13259775"
}
```

When parsing the event using the ConsoleCloudEventParser parser, we got the following warning traces:

```
2024-04-02 07:27:41,035 [thread=Test worker] [WARN ] [com.networknt.schema.JsonMetaSchema] - Unknown keyword $id - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
2024-04-02 07:27:41,036 [thread=Test worker] [WARN ] [com.networknt.schema.JsonMetaSchema] - Unknown keyword title - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
2024-04-02 07:27:41,036 [thread=Test worker] [WARN ] [com.networknt.schema.JsonMetaSchema] - Unknown keyword description - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
2024-04-02 07:27:41,094 [thread=Test worker] [WARN ] [com.networknt.schema.JsonMetaSchema] - Unknown keyword contentEncoding - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
```

After adding the simple slf4j appender for tests, this is also reproducible using the existing tests, for ex: ConsoleCloudEventParserTest.shouldParseCorrectCloudEvents. 